### PR TITLE
Fix error when no active app can be selected

### DIFF
--- a/samples/mycompany.sh
+++ b/samples/mycompany.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Default value but can be overriden
+API_BASE_URL=${API_BASE_URL:-http:/localhost:8081/api}
+
 set -ex
 HOST=`echo $API_BASE_URL | awk -F/ '{print $3}'`
 BASEPATH=`echo $API_BASE_URL | grep / | cut -d/ -f4-`
@@ -302,6 +305,12 @@ curl --request PUT \
 	}
 }'
 
+curl --request POST \
+  --url $API_BASE_URL/v1/applications/web/ui/versions/1.0.0/deploy/staging \
+  --header 'content-type: application/json' \
+  --data "{
+		}
+	}"
 
 curl --request PUT \
   --url $API_BASE_URL/v1/badges/readme \

--- a/webui/src/app/components/appdetail/appdetail.component.ts
+++ b/webui/src/app/components/appdetail/appdetail.component.ts
@@ -45,6 +45,11 @@ export class AppdetailComponent implements OnInit {
   ngOnInit(): void {
     this.applicationSubscription = this.applicationStream.subscribe(
       (app: ApplicationBean) => {
+        // With full text search, active application can be undefined
+        // Just check if app is undefined
+        if (!app) {
+          return;
+        }
         this.application = app;
 
         // Rule is
@@ -63,14 +68,14 @@ export class AppdetailComponent implements OnInit {
         // When read field exist use it as plain text
         // Or if it's an url call it to obtain data
 
-        this._activeDeployments = []
+        this._activeDeployments = [];
         this._selectedDeployment = null;
         if (this.application.deployments !== undefined) {
           this.application.deployments.forEach(value => {
             if (!value.undeployedAt || value.undeployedAt === null) {
               this._activeDeployments.push(value);
               if (this._selectedDeployment === null) {
-                this._selectedDeployment = value
+                this._selectedDeployment = value;
               }
             }
           });

--- a/webui/src/app/components/applications/applications.component.ts
+++ b/webui/src/app/components/applications/applications.component.ts
@@ -39,7 +39,7 @@ export class ApplicationsComponent implements OnInit {
 
   public domain = '';
   public param = { target: '' };
-  protected searchString = ''
+  protected searchString = '';
 
   protected orderedDomains = new Map<string, ApplicationBean[]>();
   public domains: DomainBean[] = [];
@@ -178,6 +178,6 @@ export class ApplicationsComponent implements OnInit {
 
   public onFilterKeyPressed(event: any) {
     this.searchString = event.target.value;
-    this.refreshApplications()
+    this.refreshApplications();
   }
 }

--- a/webui/src/app/stores/applications-store.service.ts
+++ b/webui/src/app/stores/applications-store.service.ts
@@ -2,7 +2,8 @@ import { Injectable } from '@angular/core';
 import { createFeatureSelector, createSelector, Selector, Store } from '@ngrx/store';
 
 import { ActionWithPayloadAndPromise } from './action-with-payload';
-import { ApplicationBean, ApplicationPagesBean, DeploymentBean, DomainBean, DomainPagesBean, BadgeRatingBean } from '../models/commons/applications-bean';
+import { ApplicationBean, ApplicationPagesBean,
+  DeploymentBean, DomainBean, DomainPagesBean, BadgeRatingBean } from '../models/commons/applications-bean';
 import { Subject } from 'rxjs/Subject';
 
 /**
@@ -125,12 +126,19 @@ export class ApplicationsStoreService {
           domains.push({name: k, applications: v});
         });
 
+        const firstApp = pages.applications[0];
+        if (!firstApp) {
+          console.warn('No active application can be selected');
+        }
+
         action.subject.complete();
         return {
           domainPages: state.domainPages,
           domains: domains,
           applications: pages,
-          active: pages.applications[0],
+          // Undefined must be check in all client
+          // of this stream
+          active: firstApp,
         };
       }
 
@@ -157,7 +165,7 @@ export class ApplicationsStoreService {
        */
       case SelectApplicationAction.getType(): {
         action = action as SelectApplicationAction;
-        var active = Object.assign({}, action.payload);
+        const active = Object.assign({}, action.payload);
 
         /**
          * notify domains change


### PR DESCRIPTION
Fix error when no active app can be selected, while searching with no result

Select all apps, then select one app
Go back in browser and type searching string which select no apps

> main.877f51b0a97e0dcbfd68.bundle.js:1 ERROR TypeError: Cannot read property 'properties' of undefined
>     at t._next (main.877f51b0a97e0dcbfd68.bundle.js:1)
>     at t.__tryOrUnsub (main.877f51b0a97e0dcbfd68.bundle.js:1)
>     at t.next (main.877f51b0a97e0dcbfd68.bundle.js:1)
>     at t._next (main.877f51b0a97e0dcbfd68.bundle.js:1)
>     at t.next (main.877f51b0a97e0dcbfd68.bundle.js:1)
>     at t._next (main.877f51b0a97e0dcbfd68.bundle.js:1)
>     at t.next (main.877f51b0a97e0dcbfd68.bundle.js:1)
>     at t._next (main.877f51b0a97e0dcbfd68.bundle.js:1)
>     at t.next (main.877f51b0a97e0dcbfd68.bundle.js:1)
>     at t.next (main.877f51b0a97e0dcbfd68.bundle.js:1)