### PR TITLE
Improve/add-vendor-only-to-dep-ensure

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -465,6 +465,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "42cdb355dffc0255598ce1cdd816db43517353d794ac35659f80aab0697a1dad"
+  inputs-digest = "adc783119b569d0c0442d51b3485a7d2bfdc020e863260fb14049ac01c639fe6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/Gopkg.toml
+++ b/api/Gopkg.toml
@@ -60,3 +60,8 @@ required = ["github.com/ovh/venom", "github.com/golang/lint/golint"]
 [[override]]
   name = "github.com/valyala/fasthttp"
   branch = "master"
+
+[prune]
+  non-go = true
+  go-tests = true
+  unused-packages = true

--- a/api/Makefile
+++ b/api/Makefile
@@ -34,7 +34,7 @@ $(PACKR):
 	go get -u github.com/gobuffalo/packr/packr
 
 install: $(GO_DEP) $(PACKR)
-	dep ensure
+	dep ensure -vendor-only
 	packr
 
 server: vet lint install


### PR DESCRIPTION
Gain : build faster

I propose to modifiy dep ensure call args : add -vendor-only

And as you see these line in .toml
```
[prune]
  non-go = true
  go-tests = true
  unused-packages = true
```
permit to reduce vendor folder size
