### PR TITLE
Fix inconsistency of latest when recreating a deleted release

### DIFF
--- a/api/v1/application/latest.go
+++ b/api/v1/application/latest.go
@@ -65,5 +65,5 @@ func shouldUpdate(current, submitted *v1.Release, log *logrus.Entry) bool {
 	if err != nil {
 		return true
 	}
-	return currentSemver.LessThan(*submittedSemver)
+	return currentSemver.Compare(*submittedSemver) <= 0
 }


### PR DESCRIPTION
Since the semvers were equals, the latest reference were not updated, causing a `410 Gone` error