### PR TITLE
Change badgerating storage to a map

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -480,6 +480,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "dbcd3db3780ee5523ebdb6dfb92c913ec3ca998061741ba97bb71674f1b1ccda"
+  inputs-digest = "5c1b53c24aa2f2656c9b452b5a123b437af078e2d172d086729d8b9fe21a12e1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/handlers/middleware.go
+++ b/api/handlers/middleware.go
@@ -73,7 +73,7 @@ func HasOne(roles ...security.Role) gin.HandlerFunc {
 			return
 		}
 		if log != nil {
-			log.WithField("expectedRoles", roles).Info("unauthorized access")
+			log.WithField("expectedRoles", roles).WithField("roles", rolePolicy.ToSlice()).Info("unauthorized access")
 		}
 		abortUnauthorized(c)
 	}

--- a/api/security/type.go
+++ b/api/security/type.go
@@ -14,8 +14,9 @@ type RolePolicy map[Role]bool
 
 // Existing roles
 const (
-	RoleAdmin Role = "ROLE_ADMIN"
-	RoleUser       = "ROLE_USER"
+	RoleAdmin        Role = "ROLE_ADMIN"
+	RoleUser              = "ROLE_USER"
+	RoleBadgeCreator      = "ROLE_BADGE_CREATOR"
 )
 
 // User is a human user

--- a/api/v1/application/badge_rating_test.go
+++ b/api/v1/application/badge_rating_test.go
@@ -65,12 +65,15 @@ func TestBadgeRatingList(t *testing.T) {
 	mockSelectApplications(
 		[]map[string]interface{}{
 			{
-				"badge_ratings": []byte(`[
-				{
-					"badgeslug": "mybadge2",
-					"value": "good",
-					"comment": "tests passed"
-				}]`),
+				"name":    "myapp",
+				"domain":  "mydomain",
+				"version": "1.2.3",
+				"badge_ratings": []byte(`{
+					"mybadge2": {
+						"value": "good",
+						"comment": "tests passed"
+					}
+				}`),
 			},
 		},
 	)
@@ -81,7 +84,6 @@ func TestBadgeRatingList(t *testing.T) {
 		Status(http.StatusOK).
 		JSON().Array().Equal([]map[string]interface{}{
 		{
-			"badgeslug":  "mybadge1",
 			"badgetitle": "My Badge 1",
 			"value":      "unset",
 			"comment":    "",
@@ -92,9 +94,18 @@ func TestBadgeRatingList(t *testing.T) {
 				"description": "",
 				"isdefault":   true,
 			},
+			"_links": []interface{}{
+				map[string]string{
+					"href": "/api/v1/badges/mybadge1",
+					"rel":  "badge",
+				},
+				map[string]string{
+					"href": "/api/v1/applications/mydomain/myapp/versions/1.2.3",
+					"rel":  "release",
+				},
+			},
 		},
 		{
-			"badgeslug":  "mybadge2",
 			"badgetitle": "My Badge 2",
 			"value":      "good",
 			"comment":    "tests passed",
@@ -104,6 +115,16 @@ func TestBadgeRatingList(t *testing.T) {
 				"color":       "green",
 				"description": "",
 				"isdefault":   false,
+			},
+			"_links": []interface{}{
+				map[string]string{
+					"href": "/api/v1/badges/mybadge2",
+					"rel":  "badge",
+				},
+				map[string]string{
+					"href": "/api/v1/applications/mydomain/myapp/versions/1.2.3",
+					"rel":  "release",
+				},
 			},
 		},
 	})
@@ -152,13 +173,12 @@ func TestBadgeRatingSetSuccess(t *testing.T) {
 		[]map[string]interface{}{
 			{
 				"id": 1,
-				"badge_ratings": []byte(`[
-				{
-					"badgeslug": "mybadge2",
-					"value": "good",
-					"comment": "tests passed"
-					
-				}]`),
+				"badge_ratings": []byte(`{
+					"mybadge2": {
+						"value": "good",
+						"comment": "tests passed"
+					}
+				}`),
 			},
 		},
 	)
@@ -206,13 +226,12 @@ func TestBadgeRatingSetLevelNotFound(t *testing.T) {
 	mockSelectApplications(
 		[]map[string]interface{}{
 			{
-				"badge_ratings": []byte(`[
-				{
-					"badgeslug": "mybadge2",
-					"value": "good",
-					"comment": "tests passed"
-					
-				}]`),
+				"badge_ratings": []byte(`{
+					"mybadge2": {
+						"value": "good",
+						"comment": "tests passed"
+					}
+				}`),
 			},
 		},
 	)
@@ -243,13 +262,12 @@ func TestBadgeRatingSetBadgeNotFound(t *testing.T) {
 	mockSelectApplications(
 		[]map[string]interface{}{
 			{
-				"badge_ratings": []byte(`[
-				{
-					"badgeslug": "mybadge2",
-					"value": "good",
-					"comment": "tests passed"
-					
-				}]`),
+				"badge_ratings": []byte(`{
+					"mybadge2": {
+						"value": "good",
+						"comment": "tests passed"
+					}
+				}`),
 			},
 		},
 	)
@@ -337,18 +355,17 @@ func TestBadgeRatingDeleteSuccess(t *testing.T) {
 	mockSelectApplications(
 		[]map[string]interface{}{
 			{
-				"badge_ratings": []byte(`[
-				{
-					"badgeslug": "mybadge2",
-					"value": "thisisadeprecatedvalue",
-					"comment": ""
-					
-				}]`),
+				"badge_ratings": []byte(`{
+					"mybadge2": {
+						"value": "thisisadeprecatedvalue",
+						"comment": ""
+					}
+				}`),
 			},
 		},
 	)
 
-	m := mocket.Catcher.NewMock().WithQuery(`INSERT INTO "releases" ("properties","manifest","tags","created_at","updated_at","deleted_at","badge_ratings")`)
+	m := mocket.Catcher.NewMock().WithQuery(`INSERT INTO "releases"`)
 
 	e := httpexpect.New(t, server.URL)
 	e.DELETE("/api/v1/applications/mydomain/myapp/versions/1.0.0/badgeratings/mybadge2").

--- a/api/v1/badge/handlers.go
+++ b/api/v1/badge/handlers.go
@@ -41,8 +41,10 @@ func HandlerCreate(repository *Repository) gin.HandlerFunc {
 
 // HandlerStats computes and renders badge statistics
 func HandlerStats(repo *Repository) gin.HandlerFunc {
-	return tonic.Handler(func(c *gin.Context, b *v1.Badge) (*v1.Badge, error) {
-
-		return nil, nil
+	return tonic.Handler(func(c *gin.Context, b *v1.Badge) (map[string]int, error) {
+		if _, err := repo.FindOneBySlug(b.Slug); err != nil {
+			return nil, err
+		}
+		return repo.GatherStats(b.Slug)
 	}, http.StatusOK)
 }

--- a/api/v1/badge/handlers.go
+++ b/api/v1/badge/handlers.go
@@ -38,3 +38,11 @@ func HandlerCreate(repository *Repository) gin.HandlerFunc {
 		return bdg, nil
 	}, http.StatusOK)
 }
+
+// HandlerStats computes and renders badge statistics
+func HandlerStats(repo *Repository) gin.HandlerFunc {
+	return tonic.Handler(func(c *gin.Context, b *v1.Badge) (*v1.Badge, error) {
+
+		return nil, nil
+	}, http.StatusOK)
+}

--- a/api/v1/resources.go
+++ b/api/v1/resources.go
@@ -211,7 +211,11 @@ func (badge *Badge) GetDeletedAt() *time.Time {
 
 // ToResource implements Resourceable
 func (badge *Badge) ToResource(baseURL string) {
-	badge.Resource.Links = []hateoas.ResourceLink{{Rel: "self", Href: badge.GetSelfURL(baseURL)}}
+	selfURL := badge.GetSelfURL(baseURL)
+	badge.Resource.Links = []hateoas.ResourceLink{
+		{Rel: "self", Href: selfURL},
+		{Rel: "stats", Href: selfURL + "/stats"},
+	}
 }
 
 // GetSelfURL implements Resourceable

--- a/api/v1/resources.go
+++ b/api/v1/resources.go
@@ -218,3 +218,16 @@ func (badge *Badge) ToResource(baseURL string) {
 func (badge *Badge) GetSelfURL(baseURL string) string {
 	return fmt.Sprintf("%s%s/%s", baseURL, BadgeBasePath, badge.Slug)
 }
+
+// ToResource implements Resourceable
+func (br *BadgeRating) ToResource(baseURL string) {
+	br.Resource.Links = []hateoas.ResourceLink{
+		{Rel: "badge", Href: br.Badge.GetSelfURL(baseURL)},
+		{Rel: "release", Href: br.Release.GetSelfURL(baseURL)},
+	}
+}
+
+// GetSelfURL implements Resourceable
+func (br *BadgeRating) GetSelfURL(baseURL string) string {
+	return ""
+}

--- a/api/v1/routing/routes.go
+++ b/api/v1/routing/routes.go
@@ -137,10 +137,10 @@ func registerRoutes(group *fizz.RouterGroup,
 	), application.HandlerGetBadgeRatingsForAppVersion(appRepo))
 	appRoutes.PUT("/:domain/:name/versions/:version/badgeratings/:badgeslug", getOperationOptions("SetBadgeRatingForAnApplicationVersion", appRepo,
 		fizz.Summary("Set badge value for an application version"),
-	), handlers.HasOne(security.RoleAdmin), application.HandlerSetBadgeRatingForRelease(appRepo, badgeRepo))
+	), handlers.HasOne(security.RoleAdmin, security.RoleBadgeCreator), application.HandlerSetBadgeRatingForRelease(appRepo, badgeRepo))
 	appRoutes.DELETE("/:domain/:name/versions/:version/badgeratings/:badgeslug", getOperationOptions("DeleteBadgeRatingForAnApplicationVersion", appRepo,
 		fizz.Summary("Delete badge value for an application version"),
-	), handlers.HasOne(security.RoleAdmin), application.HandlerDeleteBadgeRatingForRelease(appRepo))
+	), handlers.HasOne(security.RoleAdmin, security.RoleBadgeCreator), application.HandlerDeleteBadgeRatingForRelease(appRepo))
 
 	envRoutes := group.Group("/environments", "environments", "Environments resource management")
 	envRoutes.GET("/", getOperationOptions("FindByPage", envRepo,
@@ -195,7 +195,7 @@ func registerRoutes(group *fizz.RouterGroup,
 	), hateoas.HandlerFindOneBy(badgeRepo))
 	badgeRoutes.PUT("/:slug", getOperationOptions("Create", badgeRepo,
 		fizz.Summary("Create a Badge"),
-	), handlers.HasOne(security.RoleAdmin), badge.HandlerCreate(badgeRepo))
+	), handlers.HasOne(security.RoleAdmin, security.RoleBadgeCreator), badge.HandlerCreate(badgeRepo))
 	badgeRoutes.DELETE("/:slug", getOperationOptions("RemoveOneBy", badgeRepo,
 		fizz.Summary("Remove a Badge"),
 		fizz.InputModel(v1.Badge{}),

--- a/api/v1/routing/routes.go
+++ b/api/v1/routing/routes.go
@@ -39,6 +39,7 @@ func registerRoutes(group *fizz.RouterGroup,
 		hateoas.ResourceLink{Href: v1.ApplicationBasePath, Rel: "applications"},
 		hateoas.ResourceLink{Href: v1.EnvironmentBasePath, Rel: "environments"},
 		hateoas.ResourceLink{Href: v1.DeploymentBasePath, Rel: "deployments"},
+		hateoas.ResourceLink{Href: v1.BadgeBasePath, Rel: "badges"},
 	))
 
 	graphRoutes := group.Group("/graphs", "graph", "Graphs node and edge management")
@@ -136,10 +137,10 @@ func registerRoutes(group *fizz.RouterGroup,
 	), application.HandlerGetBadgeRatingsForAppVersion(appRepo))
 	appRoutes.PUT("/:domain/:name/versions/:version/badgeratings/:badgeslug", getOperationOptions("SetBadgeRatingForAnApplicationVersion", appRepo,
 		fizz.Summary("Set badge value for an application version"),
-	), handlers.HasOne(security.RoleAdmin), application.HandlerSetBadgeRatingForAppVersion(appRepo))
+	), handlers.HasOne(security.RoleAdmin), application.HandlerSetBadgeRatingForRelease(appRepo, badgeRepo))
 	appRoutes.DELETE("/:domain/:name/versions/:version/badgeratings/:badgeslug", getOperationOptions("DeleteBadgeRatingForAnApplicationVersion", appRepo,
 		fizz.Summary("Delete badge value for an application version"),
-	), handlers.HasOne(security.RoleAdmin), application.HandlerDeleteBadgeRatingForAppVersion(appRepo))
+	), handlers.HasOne(security.RoleAdmin), application.HandlerDeleteBadgeRatingForRelease(appRepo))
 
 	envRoutes := group.Group("/environments", "environments", "Environments resource management")
 	envRoutes.GET("/", getOperationOptions("FindByPage", envRepo,
@@ -199,7 +200,9 @@ func registerRoutes(group *fizz.RouterGroup,
 		fizz.Summary("Remove a Badge"),
 		fizz.InputModel(v1.Badge{}),
 	), handlers.HasOne(security.RoleAdmin), hateoas.HandlerRemoveOneBy(badgeRepo))
-
+	badgeRoutes.GET("/:slug/stats", getOperationOptions("ComputeStats", badgeRepo,
+		fizz.Summary("Compute badge statistics"),
+	), badge.HandlerStats(badgeRepo))
 }
 
 // Init initialize the API v1 module

--- a/api/v1/type.go
+++ b/api/v1/type.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/ovh/lhasa/api/graphapi"
 	"github.com/ovh/lhasa/api/hateoas"
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 )
 
 // ApplicationBasePath is the URL base path for this resource
@@ -165,6 +165,18 @@ type Badge struct {
 	CreatedAt time.Time      `json:"_createdAt" binding:"-"`
 	UpdatedAt time.Time      `json:"_updatedAt" binding:"-"`
 	DeletedAt *time.Time     `json:"-" binding:"-"`
+	hateoas.Resource
+}
+
+// BadgeRating is a rating for a badge
+type BadgeRating struct {
+	BadgeID    string      `json:"badgeslug,omitempty" validate:"not null; not empty"`
+	Badge      *Badge      `json:"-"`
+	Release    *Release    `json:"-"`
+	BadgeTitle string      `json:"badgetitle,omitempty"`
+	Value      string      `json:"value" validate:"not null; not empty"`
+	Comment    string      `json:"comment"`
+	Level      *BadgeLevel `json:"level,omitempty"`
 	hateoas.Resource
 }
 

--- a/migrations/v0009.sql
+++ b/migrations/v0009.sql
@@ -1,0 +1,5 @@
+-- +migrate Down
+
+UPDATE releases SET badge_ratings = NULL;
+
+-- +migrate Up

--- a/tests/50-badges-v1.yml
+++ b/tests/50-badges-v1.yml
@@ -115,10 +115,16 @@ testcases:
       url: "{{.appsroute}}/mydomain/myappp/versions/1.0.0/badges"
       assertions:
       - result.statuscode ShouldEqual 200
-      - result.bodyjson.bodyjson0.badgeslug ShouldEqual readme
       - result.bodyjson.bodyjson0.badgetitle ShouldEqual README.md
       - result.bodyjson.bodyjson0.level.color ShouldEqual green
       - result.bodyjson.bodyjson0.comment ShouldEqual "340 lines"
       - result.bodyjson.bodyjson0.level.label ShouldEqual ✔
       - result.bodyjson.bodyjson0.value ShouldEqual exists
       - result.bodyjson.bodyjson0.level.description ShouldEqual desc5
+    - type: http
+      method: GET
+      url: "{{.badgesroute}}/readme/stats"
+      assertions:
+      - result.statuscode ShouldEqual 200
+      - result.bodyjson.exists ShouldEqual 1
+


### PR DESCRIPTION
This PR adds a `/v1/badges/:slug/stats` route that outputs statistics for a given badge.

```curl
curl --request GET \
  --url $API/v1/badges/readme/stats
```
```json
{
	"exists": 1,
	"tooshort": 2
}
```