### PR TITLE
Factorize hateoas link generation

### DIFF
--- a/api/handlers/hooks.go
+++ b/api/handlers/hooks.go
@@ -80,14 +80,18 @@ func BindHook(c *gin.Context, i interface{}) error {
 	return nil
 }
 
-// RenderHook hook for lhasa, override default one
-func RenderHook(c *gin.Context, status int, payload interface{}) {
-	// Scan interface implementation
-	media, ok := payload.(MediaResource)
-	if ok {
-		c.Data(http.StatusOK, media.GetContentType(), media.GetBytes())
-		return
+// RenderHookWrapper hook for lhasa, override default one
+func RenderHookWrapper(hook tonic.RenderHook) tonic.RenderHook {
+	return func(c *gin.Context, status int, payload interface{}) {
+		// Scan interface implementation
+		media, ok := payload.(MediaResource)
+		if ok {
+			c.Data(http.StatusOK, media.GetContentType(), media.GetBytes())
+			return
+		}
+		if hook == nil {
+			return
+		}
+		hook(c, status, payload)
 	}
-
-	tonic.DefaultRenderHook(c, status, payload)
 }

--- a/api/handlers/middleware.go
+++ b/api/handlers/middleware.go
@@ -37,7 +37,7 @@ func RecoveryWithLogger(log logrus.FieldLogger) gin.HandlerFunc {
 					stack := stack(3)
 					httprequest, _ := httputil.DumpRequest(c.Request, false)
 					log.WithField("error", err).
-						WithField("full_message", stack).
+						WithField("full_message", string(stack)).
 						WithField("request", string(httprequest)).
 						Error("panic recovered")
 				}

--- a/api/hateoas/handlers.go
+++ b/api/hateoas/handlers.go
@@ -56,9 +56,6 @@ func HandlerFindBy(repository ListableRepository) gin.HandlerFunc {
 func HandlerFindOneBy(repository ListableRepository) gin.HandlerFunc {
 	return tonic.Handler(func(c *gin.Context) (interface{}, error) {
 		result, err := FindByPath(c, repository)
-		if resource, ok := result.(Resourceable); ok {
-			resource.ToResource(BaseURL(c))
-		}
 		if err != nil {
 			return nil, err
 		}

--- a/api/hateoas/hooks.go
+++ b/api/hateoas/hooks.go
@@ -1,0 +1,21 @@
+package hateoas
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/loopfz/gadgeto/tonic"
+)
+
+// RenderHookWrapper handles hateoas entity conversion
+func RenderHookWrapper(hook tonic.RenderHook) tonic.RenderHook {
+	return func(c *gin.Context, status int, payload interface{}) {
+		baseURL := BaseURL(c)
+		switch r := payload.(type) {
+		case Resourceable:
+			r.ToResource(baseURL)
+		}
+		if hook == nil {
+			return
+		}
+		hook(c, status, payload)
+	}
+}

--- a/api/hateoas/type.go
+++ b/api/hateoas/type.go
@@ -166,8 +166,7 @@ func reflectValueToResource(value reflect.Value, baseURL string) {
 		}
 		return
 	}
-	resource, ok := value.Interface().(Resourceable)
-	if ok {
+	if resource, ok := value.Interface().(Resourceable); ok {
 		resource.ToResource(baseURL)
 	}
 }

--- a/api/routing/routes.go
+++ b/api/routing/routes.go
@@ -46,7 +46,7 @@ func NewRouter(tm db.TransactionManager, c config.Lhasa, version, hateoasBaseBat
 
 	tonic.SetErrorHook(hateoas.ErrorHook(jujerr.ErrHook))
 	tonic.SetBindHook(handlers.BindHook)
-	tonic.SetRenderHook(handlers.RenderHook, "")
+	tonic.SetRenderHook(handlers.RenderHookWrapper(hateoas.RenderHookWrapper(tonic.DefaultRenderHook)), "")
 
 	api := router.Group("/api", "", "", hateoas.AddToBasePath(hateoasBaseBath), handlers.AuthMiddleware(c.Policy))
 	api.GET("/", []fizz.OperationOption{

--- a/api/tests/fixtures.go
+++ b/api/tests/fixtures.go
@@ -16,7 +16,7 @@ import (
 
 // StartTestHTTPServer starts a fake http server for testing purposes
 func StartTestHTTPServer() *httptest.Server {
-	log := logger.NewLogger(true, true, false, true)
+	log := logger.NewLogger(true, true, false, false)
 	mocket.Catcher.Register()
 	mocket.Catcher.Reset()
 	mocket.Catcher.Logging = true

--- a/api/v1/application/latest.go
+++ b/api/v1/application/latest.go
@@ -10,11 +10,11 @@ import (
 )
 
 // LatestUpdater updates the application latest version to the given version
-type LatestUpdater func(*v1.Release) error
+type LatestUpdater func(*v1.Release, logrus.FieldLogger) error
 
 // NewLatestUpdater instantiates a LatestUpdater
-func NewLatestUpdater(tm db.TransactionManager, appRepoFactory RepositoryFactory, latestRepoFactory RepositoryLatestFactory, log logrus.FieldLogger) LatestUpdater {
-	return func(version *v1.Release) error {
+func NewLatestUpdater(tm db.TransactionManager, appRepoFactory RepositoryFactory, latestRepoFactory RepositoryLatestFactory) LatestUpdater {
+	return func(version *v1.Release, log logrus.FieldLogger) error {
 		return tm.Transaction(func(db *gorm.DB) error {
 			appRepo := appRepoFactory(db)
 			latestRepo := latestRepoFactory(db)

--- a/api/v1/deployment/handlers.go
+++ b/api/v1/deployment/handlers.go
@@ -1,6 +1,7 @@
 package deployment
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -89,12 +90,10 @@ func HandlerFindDeployment(appRepo *application.Repository, envRepo *environment
 		if err != nil {
 			return nil, err
 		}
-		dep := res.(*v1.Deployment)
-		dep.ToResource(hateoas.BaseURL(c))
-		if err != nil {
-			return nil, err
+		if dep, ok := res.(*v1.Deployment); ok {
+			return dep, nil
 		}
-		return dep, nil
+		return nil, fmt.Errorf("returned entity %T is not a deployment", res)
 	}, http.StatusOK)
 }
 
@@ -105,9 +104,6 @@ func HandlerListApplicationActiveDeployments(appRepo application.FindOneByUnique
 		deps, err := depRepo.FindActivesBy(request.Domain, request.Name, criteria)
 		if err != nil {
 			return nil, err
-		}
-		for _, dep := range deps {
-			dep.ToResource(hateoas.BaseURL(c))
 		}
 		return deps, nil
 	}, http.StatusOK)
@@ -120,9 +116,6 @@ func HandlerListReleaseActiveDeployments(appRepo application.FindOneByUniqueKey,
 		deps, err := depRepo.FindActivesByRelease(request.Domain, request.Name, request.Version, criteria)
 		if err != nil {
 			return nil, err
-		}
-		for _, dep := range deps {
-			dep.ToResource(hateoas.BaseURL(c))
 		}
 		return deps, nil
 	}, http.StatusOK)

--- a/api/v1/routing/routes.go
+++ b/api/v1/routing/routes.go
@@ -217,7 +217,7 @@ func Init(tm db.TransactionManager, group *fizz.RouterGroup, log logrus.FieldLog
 	deployer := deployment.ApplicationDeployer(tm, deployment.NewRepository)
 	depRepo := deployment.NewRepository(tm.DB())
 	depend := deployment.Dependency(depRepo)
-	latestUpdater := application.NewLatestUpdater(tm, application.NewRepository, application.NewRepositoryLatest, log)
+	latestUpdater := application.NewLatestUpdater(tm, application.NewRepository, application.NewRepositoryLatest)
 
 	registerRoutes(group, graphRepo, domRepo, appRepo, appLatestRepo, contRepo, envRepo, depRepo, badgeRepo, deployer, depend, latestUpdater)
 }


### PR DESCRIPTION
Instead of calling explicitely ToResource in each hateoas handler, the tonic RenderHook will now check if the returned object is a Resource, and perform the link generation.