### PR TITLE
Remove ugly policy compilation

### DIFF
--- a/api/config/loader.go
+++ b/api/config/loader.go
@@ -8,14 +8,21 @@ import (
 	"github.com/ovh/lhasa/api/security"
 )
 
+// Empty returns an empty configuration struct
+func Empty() Lhasa {
+	return Lhasa{
+		Policy: make(security.Policy),
+	}
+}
+
 // LoadFromFile extract configuration file
 func LoadFromFile(configFile *os.File) (config Lhasa, err error) {
+	config = Empty()
 	// Init config file
 	b, err := ioutil.ReadFile(configFile.Name())
 	if err != nil {
-		return Lhasa{}, err
+		return config, err
 	}
 	err = json.Unmarshal(b, &config)
-	config.Policy = security.Compile(config.Security)
 	return config, err
 }

--- a/api/config/type.go
+++ b/api/config/type.go
@@ -7,8 +7,7 @@ import (
 
 // Lhasa is the main config format
 type Lhasa struct {
-	DB         db.DatabaseCredentials  `json:"appcatalog-db"`
-	Security   security.Policy         `json:"security"`
-	Policy     security.CompiledPolicy `json:"-"`
-	LogHeaders []string                `json:"log-headers"`
+	DB         db.DatabaseCredentials `json:"appcatalog-db"`
+	Policy     security.Policy        `json:"security"`
+	LogHeaders []string               `json:"log-headers"`
 }

--- a/api/handlers/middleware.go
+++ b/api/handlers/middleware.go
@@ -177,7 +177,7 @@ func abortUnauthorized(c *gin.Context) {
 }
 
 // AuthMiddleware returns a middleware that populate the Gin Context with security data
-func AuthMiddleware(policy security.CompiledPolicy) gin.HandlerFunc {
+func AuthMiddleware(policy security.Policy) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		roles := security.BuildRolePolicy(policy, c.Request)
 		c.Set(KeyRoles, roles)

--- a/api/security/policy.go
+++ b/api/security/policy.go
@@ -36,28 +36,8 @@ func (policy RolePolicy) ToSlice() (roles []Role) {
 	return
 }
 
-// Compile a policy while compiling values as glob
-func Compile(policy Policy) CompiledPolicy {
-	p := CompiledPolicy{}
-	for role, headers := range policy {
-		p[role] = map[string][]interface{}{}
-		for header, patterns := range headers {
-			p[role][header] = []interface{}{}
-			for _, pattern := range patterns {
-				var v interface{} = pattern
-				g, err := glob.Compile(pattern)
-				if err == nil {
-					v = g
-				}
-				p[role][header] = append(p[role][header], v)
-			}
-		}
-	}
-	return p
-}
-
 // BuildRolePolicy returns a map of Role matching the given http request
-func BuildRolePolicy(policy CompiledPolicy, r *http.Request) RolePolicy {
+func BuildRolePolicy(policy Policy, r *http.Request) RolePolicy {
 	if r == nil {
 		return nil
 	}

--- a/api/security/policy_test.go
+++ b/api/security/policy_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gobwas/glob"
 	"github.com/ovh/lhasa/api/security"
 )
 
@@ -15,52 +16,52 @@ func TestBuildRolePolicy(t *testing.T) {
 	}{
 		{
 			policy: security.BuildRolePolicy(
-				security.Compile(security.Policy{
+				security.Policy{
 					"ROLE_ADMIN": {
 						"X-Remote-User": {"john.doe"},
 					},
 					"ROLE_USER": {
-						"X-Remote-User": {"*"},
+						"X-Remote-User": {glob.MustCompile("*")},
 					},
-				}),
+				},
 				&http.Request{Header: map[string][]string{"X-Remote-User": {"john.doe"}}}),
 			roles: []security.Role{security.RoleAdmin, security.RoleUser},
 		},
 		{
 			policy: security.BuildRolePolicy(
-				security.Compile(security.Policy{
+				security.Policy{
 					"ROLE_ADMIN": {
 						"X-Remote-User": {"john.doe"},
 					},
 					"ROLE_USER": {
-						"X-Remote-User": {"*"},
+						"X-Remote-User": {glob.MustCompile("*")},
 					},
-				}),
+				},
 				&http.Request{Header: map[string][]string{"X-Remote-User": {"foo.bar"}}}),
 			roles:   []security.Role{security.RoleUser},
 			noRoles: []security.Role{security.RoleAdmin},
 		},
 		{
 			policy: security.BuildRolePolicy(
-				security.Compile(security.Policy{
+				security.Policy{
 					"ROLE_ADMIN": {
 						"X-Ovh-Gateway-Source": {"foobar"},
 					},
 					"ROLE_USER": {
-						"X-Remote-User": {"*"},
+						"X-Remote-User": {glob.MustCompile("*")},
 					},
-				}),
+				},
 				&http.Request{Header: map[string][]string{"X-Remote-User": {"foo.bar"}}}),
 			roles:   []security.Role{security.RoleUser},
 			noRoles: []security.Role{security.RoleAdmin},
 		},
 		{
 			policy: security.BuildRolePolicy(
-				security.Compile(security.Policy{
+				security.Policy{
 					"ROLE_ADMIN": {
 						"X-Ovh-Gateway-Source": {"foobar"},
 					},
-				}),
+				},
 				&http.Request{Header: map[string][]string{"X-Ovh-Gateway-Source": {"foobar"}}}),
 			roles:   []security.Role{security.RoleAdmin},
 			noRoles: []security.Role{security.RoleUser},

--- a/api/security/type.go
+++ b/api/security/type.go
@@ -1,13 +1,16 @@
 package security
 
+import (
+	"encoding/json"
+
+	"github.com/gobwas/glob"
+)
+
 // Role defines an applicative Role
 type Role string
 
 // Policy defines a match table between roles, http headers and allowed values
-type Policy map[Role]map[string][]string
-
-// CompiledPolicy is a policy where values have been compiled as globs
-type CompiledPolicy map[Role]map[string][]interface{}
+type Policy map[Role]map[string][]interface{}
 
 // RolePolicy defines an indexed list of Role
 type RolePolicy map[Role]bool
@@ -22,4 +25,27 @@ const (
 // User is a human user
 type User struct {
 	name string
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (p Policy) UnmarshalJSON(raw []byte) error {
+	var jsonPolicy map[Role]map[string][]string
+	if err := json.Unmarshal(raw, &jsonPolicy); err != nil {
+		return err
+	}
+	for role, headers := range jsonPolicy {
+		p[role] = map[string][]interface{}{}
+		for header, patterns := range headers {
+			p[role][header] = []interface{}{}
+			for _, pattern := range patterns {
+				var v interface{} = pattern
+				g, err := glob.Compile(pattern)
+				if err == nil {
+					v = g
+				}
+				p[role][header] = append(p[role][header], v)
+			}
+		}
+	}
+	return nil
 }

--- a/api/tests/fixtures.go
+++ b/api/tests/fixtures.go
@@ -4,6 +4,7 @@ import (
 	"net/http/httptest"
 
 	mocket "github.com/Selvatico/go-mocket"
+	"github.com/gobwas/glob"
 	"github.com/ovh/lhasa/api/config"
 	"github.com/ovh/lhasa/api/db"
 	"github.com/ovh/lhasa/api/security"
@@ -22,7 +23,7 @@ func StartTestHTTPServer() *httptest.Server {
 	mocket.Catcher.Logging = true
 	dbHandle, _ := gorm.Open(mocket.DRIVER_NAME, "any_string")
 	tm := db.NewTransactionManager(dbHandle)
-	c := config.Lhasa{Policy: security.Compile(security.Policy{"ROLE_ADMIN": {"X-Remote-User": {"*"}}})}
+	c := config.Lhasa{Policy: security.Policy{"ROLE_ADMIN": {"X-Remote-User": {glob.MustCompile("*")}}}}
 	router := routers.NewRouter(tm, c, "1.0.0", "/api", "/ui", "/", "./", true, log)
 	server := httptest.NewServer(router)
 	return server


### PR DESCRIPTION
Instead of explicit, non-thread safe compiling, the policy is now compiled implicitely at json unmarshaling